### PR TITLE
use nocrypto#safely branch in travis, new PKCS1.verify signature (req…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - PINS="usane:https://github.com/hannesm/usane.git cs:https://github.com/cfcs/ocaml-cs.git nocrypto:https://github.com/mirleft/ocaml-nocrypto.git'#'79d5db2488e338d161d7e170cd681a8120ce07d1 gmap:https://github.com/hannesm/gmap.git"
+    - PINS="usane:https://github.com/hannesm/usane.git cs:https://github.com/cfcs/ocaml-cs.git nocrypto:https://github.com/hannesm/ocaml-nocrypto.git#safely"
     - PACKAGE="openpgp"
     - OPAM_VERSION=1.2.2
   matrix:
@@ -9,7 +9,6 @@ env:
     - OCAML_VERSION=4.06
 os:
   - linux
-  - osx
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 sudo: required

--- a/lib/signature_packet.ml
+++ b/lib/signature_packet.ml
@@ -342,8 +342,9 @@ The signature was not signed by this public key.|}
             (Cs.to_hex (cs_of_mpi_no_header m_pow_d_mod_n)))
       in
         e_true `Invalid_signature
-          (Nocrypto.Rsa.PKCS1.verify
-             ~hash:hash_algo
+          (let hashp = (=) hash_algo in
+           Nocrypto.Rsa.PKCS1.verify
+             ~hashp
              ~signature:(cs_of_mpi_no_header m_pow_d_mod_n |> Cs.to_cstruct)
              ~key:pub (`Digest (Cs.to_cstruct digest)))
         |> log_failed (fun m -> m "RSA signature validation failed")

--- a/opam
+++ b/opam
@@ -34,6 +34,8 @@ depends: [
   "ptime"      { >= "0.8.3" & < "0.9.0" }
   "rresult"    { >= "0.5.0" & < "0.6.0" }
   "usane"
+  "bos"        { test }
+  "fpath"      { test }
 ]
 
 depopts: [


### PR DESCRIPTION
…uiring hashp instead of hash) -- test suite returns 2 errors

also no need to pin gmap anymore, it's part of opam now (and not used here after all afaict)